### PR TITLE
Replaced '*' for required fields. Added '(optional)' for optional fields.

### DIFF
--- a/foundation_formtags/templates/foundation_formtags/foundation_form_field.html
+++ b/foundation_formtags/templates/foundation_formtags/foundation_form_field.html
@@ -17,8 +17,8 @@
     {% if field.label %}
         <label for="{{ field.auto_id }}" class={% if field.errors %}"is-invalid-label"{% endif %}>
             {{ field.label|safe }}
-                {% if field.field.required  %}
-                   <span class="required">*</span>
+                {% if not field.field.required  %}
+                   <span class="optional">(optional)</span>
                 {% endif %}
         </label>
     {% endif %}


### PR DESCRIPTION
Adding an 'optional' label to non-required fields is becoming the dominant pattern and there is some evidence that this is better understood and more accessible:

http://www.formulate.com.au/blog/required-versus-optional-fields-new-standard