### PR TITLE
Compatibility with Django 1.11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,17 @@ env:
   - TOXENV=py27-django18
   - TOXENV=py27-django19
   - TOXENV=py27-django10
+  - TOXENV=py27-django11
   - TOXENV=py27-django_trunk
   - TOXENV=py34-django18
   - TOXENV=py34-django19
   - TOXENV=py34-django10
+  - TOXENV=py34-django11
   - TOXENV=py34-django_trunk
   - TOXENV=py35-django18
   - TOXENV=py35-django19
   - TOXENV=py35-django10
+  - TOXENV=py35-django11
   - TOXENV=py35-django_trunk
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
     - env: TOXENV=py35-django18
     - env: TOXENV=py35-django19
     - env: TOXENV=py35-django10
+    - env: TOXENV=py35-django11
     - env: TOXENV=py35-django_trunk
 
 after_success: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ env:
   - TOXENV=py35-django_trunk
 
 install:
-  - pip install --upgrade pip setuptools tox virtualenv codecov 
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools tox virtualenv codecov 
 
 script:
   - tox

--- a/foundation_formtags/templatetags/foundation_formtags.py
+++ b/foundation_formtags/templatetags/foundation_formtags.py
@@ -11,7 +11,7 @@ register = template.Library()
 @register.filter
 def as_foundation(form):
     template = get_template("foundation_formtags/form.html")
-    c = Context({"form": form})
+    c = {"form": form}
     return template.render(c)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ exclude = docs/*
 
 [tox]
 envlist =
-    py27-django{18,19,10},
-    py34-django{18,19,10,_trunk},
-    py35-django{18,19,10,_trunk}
+    py27-django{18,19,10,11},
+    py34-django{18,19,10,11,_trunk},
+    py35-django{18,19,10,11,_trunk}
 
 [testenv]
 basepython = 
@@ -23,6 +23,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django10: Django>==10
+    django11: Django>=1.11,<1.12
     django_trunk: https://github.com/django/django/tarball/master
 
 commands =


### PR DESCRIPTION
Sends a dict to tpl.render instead of a Context for compatibility with Django 1.11+. Should be backwards compatible for older version of Django.