### PR TITLE
Cleaned up travis configuration for tox to improve testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,5 @@
 language: python
 
-python:
-    - 2.7
-    - 3.4
-    - 3.5
-
-env:
-  - TOXENV=py27-django18
-  - TOXENV=py27-django19
-  - TOXENV=py27-django10
-  - TOXENV=py27-django11
-  - TOXENV=py27-django_trunk
-  - TOXENV=py34-django18
-  - TOXENV=py34-django19
-  - TOXENV=py34-django10
-  - TOXENV=py34-django11
-  - TOXENV=py34-django_trunk
-  - TOXENV=py35-django18
-  - TOXENV=py35-django19
-  - TOXENV=py35-django10
-  - TOXENV=py35-django11
-  - TOXENV=py35-django_trunk
-
 install:
   - pip install --upgrade pip
   - pip install --upgrade setuptools tox virtualenv codecov 
@@ -30,14 +8,43 @@ script:
   - tox
 
 matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-django18
+    - python: 2.7
+      env: TOXENV=py27-django19
+    - python: 2.7
+      env: TOXENV=py27-django10
+    - python: 2.7
+      env: TOXENV=py27-django11
+    - python: 2.7
+      env: TOXENV=py27-django_trunk
+    - python: 3.4
+      env: TOXENV=py34-django18
+    - python: 3.4
+      env: TOXENV=py34-django19
+    - python: 3.4
+      env: TOXENV=py34-django10
+    - python: 3.4
+      env: TOXENV=py34-django11
+    - python: 3.4
+      env: TOXENV=py34-django_trunk
+    - python: 3.5
+      env: TOXENV=py35-django18
+    - python: 3.5
+      env: TOXENV=py35-django19
+    - python: 3.5
+      env: TOXENV=py35-django10
+    - python: 3.5
+      env: TOXENV=py35-django11
+TOXENV=py35-django_trunk
   allow_failures:
-    - env: TOXENV=py27-django_trunk
-    - env: TOXENV=py34-django_trunk
-    - env: TOXENV=py35-django18
-    - env: TOXENV=py35-django19
-    - env: TOXENV=py35-django10
-    - env: TOXENV=py35-django11
-    - env: TOXENV=py35-django_trunk
+    - python: 2.7
+      env: TOXENV=py27-django_trunk
+    - python: 3.4
+      env: TOXENV=py34-django_trunk
+    - python: 3.5
+      env: TOXENV=py35-django_trunk
 
 after_success: 
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ matrix:
       env: TOXENV=py35-django10
     - python: 3.5
       env: TOXENV=py35-django11
-TOXENV=py35-django_trunk
+    - python: 3.5
+      env: TOXENV=py35-django_trunk
   allow_failures:
     - python: 2.7
       env: TOXENV=py27-django_trunk


### PR DESCRIPTION
I've updated travis.yml for cleaner testing similar to [pip's setup](https://github.com/pypa/pip/blob/master/.travis.yml). This prevents travis from trying to run the 3.4/3.5 tests in python 2.7, speeds up the build by eliminating those incompatible tests, and requires all tests except against Django_trunk to pass. Currently, all required tests pass as the explicit python declaration prevents interpreter errors that forced the 3.5 environments to be in the allow_failures list.